### PR TITLE
Fixed code samples (the maps were missing a % sign)

### DIFF
--- a/lib/http_builder.ex
+++ b/lib/http_builder.ex
@@ -74,8 +74,8 @@ defmodule HttpBuilder do
 
             @behaviour HttpBuilder.Adapter
 
-            def send({method: :post, path: "/new"}), do: {:ok, new_placeholder_data }
-            def send({method: :get, path: "/items"}), do: {:ok, items_placeholder_data }
+            def send(%{method: :post, path: "/new"}), do: {:ok, new_placeholder_data }
+            def send(%{method: :get, path: "/items"}), do: {:ok, items_placeholder_data }
 
             # ... other request options.
         end

--- a/lib/http_builder.ex
+++ b/lib/http_builder.ex
@@ -12,7 +12,7 @@ defmodule HttpBuilder do
         HTTPBuilder.new()
         |> with_adapter(HttpBuilder.Adapters.HTTPoison)
         |> post("http://httparrot.com/post/1")
-        |> with_headers({"Authorization" => "Bearer token"})
+        |> with_headers(%{"Authorization" => "Bearer token"})
         |> with_json_body(%{"test" => "true"})
         |> with_request_timeout(10_000)
         |> with_receive_timeout(5_000)
@@ -31,7 +31,7 @@ defmodule HttpBuilder do
                 HTTPBuilder.new() 
                 |> with_adapter()
                 |> with_host("http://httparrot.com/")
-                |> with_headers({"Authorization" => "Bearer token"})
+                |> with_headers(%{"Authorization" => "Bearer token"})
                 |> with_request_timeout(10_000)
                 |> with_receive_timeout(5_000)
             end


### PR DESCRIPTION
  When I copy/pasted the sample docs as code, it didn't work, because of the missing "%" symbols