### PR TITLE
Preserve :ibrowse options properly

### DIFF
--- a/lib/adapters/httpotion.ex
+++ b/lib/adapters/httpotion.ex
@@ -76,8 +76,8 @@ if Code.ensure_loaded?(HTTPotion) do
                 ] 
             
             request.options
-            |> Enum.map(fn  
-                    {:ibrowse, options } -> Keyword.put(options, :connect_timeout, request.rec_timeout)
+            |> Enum.map(fn 
+                    { :ibrowse, options } -> { :ibrowse, options |> Keyword.put(:connect_timeout, request.rec_timeout) }
                     item -> item
                 end)
             |> Enum.concat(potion_options)


### PR DESCRIPTION
Hi Matthew, 

I was playing with [Fiddler](https://www.telerik.com/fiddler) to inspect the underlying HTTP calls, and noticed that `HTTPotion` adapter didn't correctly pass in `:ibrowse` options down, because the outer keyword list was flattened. 

```elixir
    HttpBuilder.new()
      |> with_adapter(HttpBuilder.Adapters.HTTPotion)
      |> with_host("http://postman-echo.com")
      |> with_options([ibrowse: [ proxy_host: '127.0.0.1', proxy_port: 8888 ]])
      |> post("/post")
      |> with_json_body(%{ "A" => "B" })
      |> send()
```